### PR TITLE
CYBOZU SUMMER BLOG FES 対応の追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v4
       with:
-        node-version-file: .tool-versions
+        node-version-file: .node-version
         cache: pnpm
 
     - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v4
       with:
-        node-version-file: .tool-versions
+        node-version-file: .node-version
         cache: pnpm
 
     - name: Install dependencies
@@ -69,7 +69,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v4
       with:
-        node-version-file: .tool-versions
+        node-version-file: .node-version
         cache: pnpm
 
     - name: Install dependencies

--- a/.github/workflows/generate-feed.yml
+++ b/.github/workflows/generate-feed.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version-file: .tool-versions
+          node-version-file: .node-version
           cache: pnpm
 
       - name: Install node packages

--- a/src/feed/generate-feed-command.ts
+++ b/src/feed/generate-feed-command.ts
@@ -1,4 +1,4 @@
-import { FEED_INFO_LIST } from '../resources/feed-info-list';
+import { getFeedInfoList } from '../resources/feed-info-list';
 import { FeedCrawler } from './utils/feed-crawler';
 import { FeedGenerator } from './utils/feed-generator';
 import * as path from 'path';
@@ -24,10 +24,12 @@ const feedStorer = new FeedStorer();
 const feedImagePrecacher = new FeedImagePrecacher();
 
 (async () => {
+  const feedInfoList = await getFeedInfoList();
+
   // フィード取得（最初は14日前以降）
   let filterArticleDate = FILTER_ARTICLE_DATE;
   let crawlFeedsResult = await feedCrawler.crawlFeeds(
-    FEED_INFO_LIST,
+    feedInfoList,
     FEED_FETCH_CONCURRENCY,
     FEED_OG_FETCH_CONCURRENCY,
     filterArticleDate,
@@ -37,7 +39,7 @@ const feedImagePrecacher = new FeedImagePrecacher();
   if (crawlFeedsResult.feedItems.length < MAX_ARTICLE_LENGTH) {
     filterArticleDate = FILTER_MORE_ARTICLE_DATE;
     crawlFeedsResult = await feedCrawler.crawlFeeds(
-      FEED_INFO_LIST,
+      feedInfoList,
       FEED_FETCH_CONCURRENCY,
       FEED_OG_FETCH_CONCURRENCY,
       filterArticleDate,

--- a/src/feed/utils/common-util.ts
+++ b/src/feed/utils/common-util.ts
@@ -1,4 +1,3 @@
-import * as v8 from 'v8';
 import * as crypto from 'crypto';
 import axios from 'axios';
 import { to } from 'await-to-js';
@@ -6,8 +5,7 @@ import { to } from 'await-to-js';
 type HatenaCountMap = Record<string, number>;
 
 export const objectDeepCopy = <T>(data: T): T => {
-  // TODO: Node.js 17 以上にしたら structuredClone 使う
-  return v8.deserialize(v8.serialize(data));
+  return structuredClone(data);
 };
 
 export const textToMd5Hash = (text: string): string => {

--- a/src/feed/utils/feed-crawler.ts
+++ b/src/feed/utils/feed-crawler.ts
@@ -188,35 +188,9 @@ export class FeedCrawler {
 
     // ブログごとの調整
     switch (feedInfo.label) {
-      case 'メルカリ':
-        // 9時間ずれているので調整
-        FeedCrawler.subtractFeedItemsDateHour(customFeed, 9);
-        customFeed.link = 'https://engineering.mercari.com/blog/';
-        break;
-      case 'KAIZEN PLATFORM':
-        // 9時間ずれているので調整
-        FeedCrawler.subtractFeedItemsDateHour(customFeed, 9);
-        break;
-      case 'Tokyo Otaku Mode':
-        customFeed.link = 'https://blog.otakumode.com/';
-        break;
-      case 'フューチャー':
-        customFeed.link = 'https://future-architect.github.io/';
-        break;
-      case 'さくら':
-        customFeed.link = 'https://knowledge.sakura.ad.jp/';
-        break;
-      case 'YOJO Technologies':
-        customFeed.title = 'YOJO Technologies Blog';
-        break;
-      case 'POL':
-        customFeed.title = 'POL テックノート';
-        break;
-      case 'mofmof':
-        customFeed.link = 'https://tech.mof-mof.co.jp';
-        break;
-      case 'CADDi':
-        customFeed.link = 'https://caddi.tech/';
+      case 'CYBOZU SUMMER BLOG FES':
+        // RSSのchannel/linkがhttps://cybozu.github.io/のため、baseUrlで上書き（isFromSummerBlogFesの判定に必要）
+        customFeed.link = feedInfo.baseUrl;
         break;
     }
 
@@ -294,14 +268,26 @@ export class FeedCrawler {
       allFeedItems = allFeedItems.concat(feed.items);
     }
 
-    // 重複を排除（linkをキーとして）
+    // 重複を排除（linkをキーとして）。SUMMER BLOG FESと他ブログの両方にある場合はFESを優先
     const feedItemMap = new Map<string, CustomRssParserItem>();
     for (const feedItem of allFeedItems) {
       if (feedItem.link) {
-        // 既に存在する場合は、より新しい日付のものを優先
         const existingItem = feedItemMap.get(feedItem.link);
-        if (!existingItem || (feedItem.isoDate && existingItem.isoDate && feedItem.isoDate > existingItem.isoDate)) {
+        const currentIsFes = FeedCrawler.isFromSummerBlogFes(feedItem);
+        const existingIsFes = existingItem ? FeedCrawler.isFromSummerBlogFes(existingItem) : false;
+
+        if (!existingItem) {
           feedItemMap.set(feedItem.link, feedItem);
+        } else if (currentIsFes && !existingIsFes) {
+          // 現在がFES・既存が他ブログ → FESを優先
+          feedItemMap.set(feedItem.link, feedItem);
+        } else if (!currentIsFes && existingIsFes) {
+          // 現在が他ブログ・既存がFES → 既存のまま（何もしない）
+        } else {
+          // 両方FES or 両方FESでない → より新しい日付のものを優先
+          if (feedItem.isoDate && existingItem.isoDate && feedItem.isoDate > existingItem.isoDate) {
+            feedItemMap.set(feedItem.link, feedItem);
+          }
         }
       }
     }
@@ -313,6 +299,13 @@ export class FeedCrawler {
     });
 
     return allFeedItems;
+  }
+
+  /**
+   * SUMMER BLOG FESのRSS由来の記事かどうかを判定する（blogLinkに summer-blog-fes を含むか）
+   */
+  private static isFromSummerBlogFes(feedItem: CustomRssParserItem): boolean {
+    return Boolean(feedItem.blogLink && feedItem.blogLink.includes('summer-blog-fes'));
   }
 
   private async fetchFeedItemOgObjectMap(feedItems: CustomRssParserItem[], concurrency: number): Promise<OgObjectMap> {
@@ -428,11 +421,6 @@ export class FeedCrawler {
     if (ogImages !== undefined) {
       for (const ogImage of ogImages) {
         const ogImageUrl = ogImage.url;
-
-        // 一部URLがおかしいものの対応
-        if (ogImageUrl && ogImageUrl.startsWith('https://tech.fusic.co.jphttps')) {
-          ogImage.url = ogImageUrl.substring('https://tech.fusic.co.jp'.length);
-        }
 
         // http から始まってなければ調整
         if (ogImageUrl && !ogImageUrl.startsWith('http')) {

--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -24,14 +24,36 @@ const createFeedInfoList = (feedInfoTuples: FeedInfoTuple[]) => {
   return feedInfoList;
 };
 
+
+/**
+ * CYBOZU SUMMER BLOG FESのRSSフィードURL
+ * https://cybozu.github.io/summer-blog-fes-{YYYY}/rss.xml
+ * の{YYYY}に、実行する年を適用する
+ */
+const CYBOZU_SUMMER_BLOG_FES_RSS_URL = 'https://cybozu.github.io/summer-blog-fes-{YYYY}/rss.xml'.replace(
+  '{YYYY}',
+  new Date().getFullYear().toString(),
+) as ValidUrl;
+
+/**
+ * CYBOZU SUMMER BLOG FESのbaseUrl
+ * https://cybozu.github.io/summer-blog-fes-{YYYY}
+ * の{YYYY}に、実行する年を適用する
+ */
+const CYBOZU_SUMMER_BLOG_FES_BASE_URL = 'https://cybozu.github.io/summer-blog-fes-{YYYY}'.replace(
+  '{YYYY}',
+  new Date().getFullYear().toString(),
+) as ValidUrl;
+
 /**
  * フィード情報一覧。アルファベット順
  * ラベルが被るとバリデーションエラーになるので別のラベルを設定してください
- * ブログリストでブログと音声コンテンツを分けて表示するために、feedとの比較用のbaseUrlとメディアタイプ（blog, podcast のみ）を設定してください
+ * ブログリストでブログと音声コンテンツを分けて表示するために、feedとの比較用のbaseUrlとメディアタイプ（blog, podcast のいずれか）を設定してください
  */
 // prettier-ignore
 export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
   // ['企業名・製品名など', 'RSS/AtomフィードのURL', feedとの比較用のbaseUrl, 'メディアタイプ（blog, podcast)],
+  ['CYBOZU SUMMER BLOG FES', CYBOZU_SUMMER_BLOG_FES_RSS_URL, CYBOZU_SUMMER_BLOG_FES_BASE_URL, 'blog'],
   ['Cybozu Vietnam Tech Sharing', 'https://tech.cybozu.vn/rss.xml','https://tech.cybozu.vn', 'blog'],
   ['Kintone Engineering Blog', 'https://blog.kintone.io/feed', 'https://blog.kintone.io/', 'blog'],
   ['サイボウズ Developer Concourse', 'https://note.com/cybozu_dev_px/m/m000a1ff77a6b/rss', 'https://note.com/cybozu_dev_px/m/m000a1ff77a6b', 'blog'],
@@ -55,10 +77,6 @@ export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
 /**
  * その他候補
  *
- * CYBOZU SUMMER BLOG FES'25のRSSフィードは入れていない。
- * 2026年開催時に、以下の対応をしたい
- * - 既存のfeedと重複したらFESの記事を優先してマージ
- * - CYBOZU SUMMER BLOG FES'26用のタグ追加（どのフィールドが使えるか確認も必要）
- * CYBOZU SUMMER BLOG FES'25のRSSフィード
- * https://cybozu.github.io/summer-blog-fes-2025/rss.xml
+ * CYBOZU SUMMER BLOG FES'YYのRSSフィードは追加済。
+ * 開催年ごとに更新するのではなく、開催年をFeed URLとBase URLに適用して設定している。
  */

--- a/src/resources/feed-info-list.ts
+++ b/src/resources/feed-info-list.ts
@@ -24,36 +24,117 @@ const createFeedInfoList = (feedInfoTuples: FeedInfoTuple[]) => {
   return feedInfoList;
 };
 
+const getYear = () => new Date().getFullYear();
+
+/** 今年のBLOG FESのRSSフィードURL */
+const getBlogFesRssUrl = (year: number) => `https://cybozu.github.io/summer-blog-fes-${year}/rss.xml` as ValidUrl;
+
+/** 今年のBLOG FESのbaseUrl */
+const getBlogFesBaseUrl = (year: number) => `https://cybozu.github.io/summer-blog-fes-${year}` as ValidUrl;
+
+/** 指定URLが存在するか（HEADで確認） */
+const existsUrl = async (url: string): Promise<boolean> => {
+  try {
+    const res = await fetch(url, { method: 'HEAD' });
+    return res.ok;
+  } catch {
+    return false;
+  }
+};
 
 /**
- * CYBOZU SUMMER BLOG FESのRSSフィードURL
- * https://cybozu.github.io/summer-blog-fes-{YYYY}/rss.xml
- * の{YYYY}に、実行する年を適用する
+ * CYBOZU SUMMER BLOG FESのRSSフィードURLとbaseUrlを解決する。
+ * 今年のURLが存在すれば今年、存在しなければ1年前のURLを返す。
  */
-const CYBOZU_SUMMER_BLOG_FES_RSS_URL = 'https://cybozu.github.io/summer-blog-fes-{YYYY}/rss.xml'.replace(
-  '{YYYY}',
-  new Date().getFullYear().toString(),
-) as ValidUrl;
+const resolveBlogFesUrls = async (): Promise<{ url: ValidUrl; baseUrl: ValidUrl }> => {
+  const thisYear = getYear();
+  const thisYearRssUrl = getBlogFesRssUrl(thisYear);
+  if (await existsUrl(thisYearRssUrl)) {
+    return { url: thisYearRssUrl, baseUrl: getBlogFesBaseUrl(thisYear) };
+  }
+  const lastYear = thisYear - 1;
+  return { url: getBlogFesRssUrl(lastYear), baseUrl: getBlogFesBaseUrl(lastYear) };
+};
 
 /**
- * CYBOZU SUMMER BLOG FESのbaseUrl
- * https://cybozu.github.io/summer-blog-fes-{YYYY}
- * の{YYYY}に、実行する年を適用する
+ * フィード情報一覧を取得する（BLOG FESは存在する年のURLに解決される）
  */
-const CYBOZU_SUMMER_BLOG_FES_BASE_URL = 'https://cybozu.github.io/summer-blog-fes-{YYYY}'.replace(
-  '{YYYY}',
-  new Date().getFullYear().toString(),
-) as ValidUrl;
+export const getFeedInfoList = async (): Promise<FeedInfo[]> => {
+  const blogFes = await resolveBlogFesUrls();
+  return createFeedInfoList([
+    ['CYBOZU SUMMER BLOG FES', blogFes.url, blogFes.baseUrl, 'blog'],
+    ['Cybozu Vietnam Tech Sharing', 'https://tech.cybozu.vn/rss.xml', 'https://tech.cybozu.vn', 'blog'],
+    ['Kintone Engineering Blog', 'https://blog.kintone.io/feed', 'https://blog.kintone.io/', 'blog'],
+    [
+      'サイボウズ Developer Concourse',
+      'https://note.com/cybozu_dev_px/m/m000a1ff77a6b/rss',
+      'https://note.com/cybozu_dev_px/m/m000a1ff77a6b',
+      'blog',
+    ],
+    ['サイボウズ Inside Out', 'https://blog.cybozu.io/feed', 'https://blog.cybozu.io/', 'blog'],
+    ['サイボウズ Necoチーム', 'https://zenn.dev/p/cybozu_neco/feed', 'https://zenn.dev/p/cybozu_neco', 'blog'],
+    [
+      'サイボウズ PeopleExperienceチーム',
+      'https://note.com/cybozu_dev_px/m/me5cfe2c532ef/rss',
+      'https://note.com/cybozu_dev_px/m/me5cfe2c532ef',
+      'blog',
+    ],
+    [
+      'サイボウズ Product Design',
+      'https://note.com/cybozu_design/m/mc12622f890cf/rss',
+      'https://note.com/cybozu_design/m/mc12622f890cf',
+      'blog',
+    ],
+    ['サイボウズ PSIRT', 'https://zenn.dev/p/cybozu_psirt/feed', 'https://zenn.dev/p/cybozu_psirt', 'blog'],
+    ['サイボウズ データチーム', 'https://zenn.dev/p/cybozu_data/feed', 'https://zenn.dev/p/cybozu_data', 'blog'],
+    ['サイボウズ 生産性向上チーム', 'https://zenn.dev/p/cybozu_ept/feed', 'https://zenn.dev/p/cybozu_ept', 'blog'],
+    [
+      'サイボウズ フロントエンド',
+      'https://zenn.dev/p/cybozu_frontend/feed',
+      'https://zenn.dev/p/cybozu_frontend',
+      'blog',
+    ],
+    ['サイボウズ セキュリティ室', 'https://note.com/security_cybozu/rss', 'https://note.com/security_cybozu', 'blog'],
+    [
+      'サイボウズ コネクト支援チーム',
+      'https://note.com/cybozutech/m/mc0c086e78c4f/rss',
+      'https://note.com/cybozutech/m/mc0c086e78c4f',
+      'blog',
+    ],
+    [
+      'サイボウズ 流氷自由帳',
+      'https://note.com/cybozutech/m/m9707f4c496e6/rss',
+      'https://note.com/cybozutech/m/m9707f4c496e6',
+      'blog',
+    ],
+    [
+      'サイボウズ フロントエンド通信',
+      'https://anchor.fm/s/ec10d0c8/podcast/rss',
+      'https://podcasters.spotify.com/pod/show/cybozu-frontend',
+      'podcast',
+    ],
+    [
+      'Cybozu Design Podcast',
+      'https://feed.podbean.com/cybozudesign/feed.xml',
+      'https://cybozudesign.podbean.com',
+      'podcast',
+    ],
+    [
+      '流氷交差点',
+      'https://feeds.soundcloud.com/users/soundcloud:users:970362685/sounds.rss',
+      'https://soundcloud.com/cybozutech',
+      'podcast',
+    ],
+  ]);
+};
 
 /**
- * フィード情報一覧。アルファベット順
- * ラベルが被るとバリデーションエラーになるので別のラベルを設定してください
- * ブログリストでブログと音声コンテンツを分けて表示するために、feedとの比較用のbaseUrlとメディアタイプ（blog, podcast のいずれか）を設定してください
+ * フィード情報一覧（同期用・BLOG FESは当年URL）。
+ * 取得処理では getFeedInfoList() を使うこと。
  */
 // prettier-ignore
 export const FEED_INFO_LIST: FeedInfo[] = createFeedInfoList([
-  // ['企業名・製品名など', 'RSS/AtomフィードのURL', feedとの比較用のbaseUrl, 'メディアタイプ（blog, podcast)],
-  ['CYBOZU SUMMER BLOG FES', CYBOZU_SUMMER_BLOG_FES_RSS_URL, CYBOZU_SUMMER_BLOG_FES_BASE_URL, 'blog'],
+  ['CYBOZU SUMMER BLOG FES', getBlogFesRssUrl(getYear()), getBlogFesBaseUrl(getYear()), 'blog'],
   ['Cybozu Vietnam Tech Sharing', 'https://tech.cybozu.vn/rss.xml','https://tech.cybozu.vn', 'blog'],
   ['Kintone Engineering Blog', 'https://blog.kintone.io/feed', 'https://blog.kintone.io/', 'blog'],
   ['サイボウズ Developer Concourse', 'https://note.com/cybozu_dev_px/m/m000a1ff77a6b/rss', 'https://note.com/cybozu_dev_px/m/m000a1ff77a6b', 'blog'],

--- a/src/site/_data/blogFeeds.js
+++ b/src/site/_data/blogFeeds.js
@@ -11,23 +11,17 @@ dayjs.tz.setDefault('Asia/Tokyo');
 
 // feed-info-list.ts から mediatype を取得
 // esbuild-register を有効にしてTypeScriptファイルを読み込む
-let FEED_INFO_LIST;
+let getFeedInfoList;
 try {
-  // esbuild-register が有効な場合、TypeScriptファイルを読み込める
   require('esbuild-register');
-  FEED_INFO_LIST = require('../../resources/feed-info-list').FEED_INFO_LIST;
+  getFeedInfoList = require('../../resources/feed-info-list').getFeedInfoList;
 } catch (error) {
   console.error('[blogFeeds] error loading feed-info-list.ts', error);
-  // TypeScriptファイルが読み込めない場合は、直接データを定義
-  // feed-info-list.ts のデータを再現
+  // TypeScriptが読み込めない場合のフォールバック（BLOG FES除く）
   const createFeedInfoList = (feedInfoTuples) => {
-    const feedInfoList = [];
-    for (const [label, url, baseUrl, mediatype] of feedInfoTuples) {
-      feedInfoList.push({ label, url, baseUrl, mediatype });
-    }
-    return feedInfoList;
+    return feedInfoTuples.map(([label, url, baseUrl, mediatype]) => ({ label, url, baseUrl, mediatype }));
   };
-  FEED_INFO_LIST = createFeedInfoList([
+  const FALLBACK_FEED_INFO_LIST = createFeedInfoList([
     ['Cybozu Vietnam Tech Sharing', 'https://tech.cybozu.vn/rss.xml', 'https://tech.cybozu.vn', 'blog'],
     ['Kintone Engineering Blog', 'https://blog.kintone.io/feed', 'https://blog.kintone.io/', 'blog'],
     ['サイボウズ Developer Concourse', 'https://note.com/cybozu_dev_px/m/m000a1ff77a6b/rss', 'https://note.com/cybozu_dev_px/m/m000a1ff77a6b', 'blog'],
@@ -46,16 +40,17 @@ try {
     ['Cybozu Design Podcast', 'https://feed.podbean.com/cybozudesign/feed.xml', 'https://cybozudesign.podbean.com', 'podcast'],
     ['流氷交差点', 'https://feeds.soundcloud.com/users/soundcloud:users:970362685/sounds.rss', 'https://soundcloud.com/cybozutech', 'podcast'],
   ]);
-}
-
-
-// baseUrl から mediatype を取得するマップを作成
-const feedUrlToMediatypeMap = new Map();
-for (const feedInfo of FEED_INFO_LIST) {
-  feedUrlToMediatypeMap.set(feedInfo.baseUrl, feedInfo.mediatype);
+  getFeedInfoList = () => Promise.resolve(FALLBACK_FEED_INFO_LIST);
 }
 
 module.exports = async () => {
+  // baseUrl から mediatype を取得するマップ（getFeedInfoList で解決したBLOG FESのURLに合わせる）
+  const feedInfoList = await getFeedInfoList();
+  const feedUrlToMediatypeMap = new Map();
+  for (const feedInfo of feedInfoList) {
+    feedUrlToMediatypeMap.set(feedInfo.baseUrl, feedInfo.mediatype);
+  }
+
   let blogFeeds = JSON.parse(await fs.readFile(path.join(__dirname, '../blog-feeds/blog-feeds.json')));
 
   // データ調整

--- a/src/site/_includes/layouts/partials/top-section.njk
+++ b/src/site/_includes/layouts/partials/top-section.njk
@@ -4,7 +4,7 @@
             <p class="ui-text-intro">
                 サイボウズのTech系ブログの更新をまとめた<br>RSSフィードを配信しています。
             </p>
-            <p class="ui-text-update-schedule">※毎日 09:00 - 18:00(JST)の1時間ごとに更新しています。</p><br>
+            <p class="ui-text-update-schedule">※毎日 09:00 - 18:00(JST)の毎時更新しています。</p><br>
             <div class="ui-component-cta ui-layout-flex">
                 <form class="ui-component-form ui-layout-grid">
                     <label class='ui-component-form__label' for='feed-url-slack'>

--- a/tests/feed-info-list.test.ts
+++ b/tests/feed-info-list.test.ts
@@ -1,4 +1,4 @@
-import { FEED_INFO_LIST, FeedInfo } from '../src/resources/feed-info-list';
+import { getFeedInfoList, FeedInfo } from '../src/resources/feed-info-list';
 import { FeedCrawler } from '../src/feed/utils/feed-crawler';
 import { describe, it, expect } from 'vitest';
 import { exponentialBackoff } from '../src/feed/utils/common-util';
@@ -8,28 +8,32 @@ const rssParser = new RssParser({
   maxRedirects: 0,
 });
 
-// 設定のテスト
-describe('FEED_INFO_LIST', () => {
-  it('FEED_INFO_LIST の設定が正しい', () => {
+// 設定のテスト（getFeedInfoList は存在する年のBLOG FES URLに解決済み）
+describe('getFeedInfoList', () => {
+  it('返すフィード一覧の設定が正しい', async () => {
+    const feedInfoList = await getFeedInfoList();
     expect(() => {
-      FeedCrawler.validateFeedInfoList(FEED_INFO_LIST);
+      FeedCrawler.validateFeedInfoList(feedInfoList);
     }).not.toThrow();
   });
 });
 
-// フィード取得テスト
+// フィード取得テスト（BLOG FESは getFeedInfoList で解決済みのURLを使用）
 describe('フィードが取得可能', () => {
-  FEED_INFO_LIST.map((feedInfo: FeedInfo) => {
-    const testTitle = `${feedInfo.label} / ${feedInfo.url}`;
-    it.concurrent(
-      testTitle,
-      async () => {
-        const feed = await exponentialBackoff(async () => {
-          return rssParser.parseURL(feedInfo.url);
-        });
-        expect(feed.items.length).toBeGreaterThanOrEqual(0);
-      },
-      180 * 1000,
-    );
-  });
+  it(
+    '各フィードが取得可能',
+    async () => {
+      const feedInfoList = await getFeedInfoList();
+      await Promise.all(
+        feedInfoList.map(async (feedInfo: FeedInfo) => {
+          const fetchFeed = async (url: string) => {
+            return exponentialBackoff(async () => rssParser.parseURL(url));
+          };
+          const feed = await fetchFeed(feedInfo.url);
+          expect(feed.items.length).toBeGreaterThanOrEqual(0);
+        }),
+      );
+    },
+    180 * 1000,
+  );
 });

--- a/tests/integration-tests/generate-feed.test.ts
+++ b/tests/integration-tests/generate-feed.test.ts
@@ -1,4 +1,4 @@
-import { FEED_INFO_LIST } from '../../src/resources/feed-info-list';
+import { getFeedInfoList } from '../../src/resources/feed-info-list';
 import { FeedCrawler } from '../../src/feed/utils/feed-crawler';
 import { FeedGenerator } from '../../src/feed/utils/feed-generator';
 import { describe, it, expect } from 'vitest';
@@ -12,10 +12,11 @@ const MAX_FEED_CONTENT_LENGTH = 500;
 const feedCrawler = new FeedCrawler();
 const feedGenerator = new FeedGenerator();
 
-describe('フィード生成', async () => {
+describe('フィード生成', () => {
   it('フィードを正しく生成できるか', async () => {
+    const allFeedInfoList = await getFeedInfoList();
     // 10個適当に取得
-    const shuffledFeedInfoList = FEED_INFO_LIST.sort(() => 0.5 - Math.random());
+    const shuffledFeedInfoList = [...allFeedInfoList].sort(() => 0.5 - Math.random());
     const feedInfoList = shuffledFeedInfoList.slice(0, 10);
 
     // フィード取得


### PR DESCRIPTION
### Cybozu SUMMER BLOG FES対応

- BLOG FESのURLとRSSフィードURLを、実行日の対象年をもとに自動設定して参照する。
- フィードの記事URLにBLOG FESと、他のブログのURLが重複していた場合は、FESの記事として追加

### その他

- 参照していない企業ブログに対する処理を削除