### PR TITLE
Ci/add takumi guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
   lint:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -27,6 +30,10 @@ jobs:
       with:
         node-version-file: .node-version
         cache: pnpm
+
+    - uses: flatt-security/setup-takumi-guard-npm@8f53b50568e4466f2d92504f349c05b9ffcb8b59 # v1
+      with:
+        bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
 
     - name: Install dependencies
       run: pnpm install
@@ -37,6 +44,9 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -49,6 +59,10 @@ jobs:
       with:
         node-version-file: .node-version
         cache: pnpm
+
+    - uses: flatt-security/setup-takumi-guard-npm@8f53b50568e4466f2d92504f349c05b9ffcb8b59 # v1
+      with:
+        bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
 
     - name: Install dependencies
       run: pnpm install
@@ -59,6 +73,9 @@ jobs:
   generate:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -71,6 +88,10 @@ jobs:
       with:
         node-version-file: .node-version
         cache: pnpm
+
+    - uses: flatt-security/setup-takumi-guard-npm@8f53b50568e4466f2d92504f349c05b9ffcb8b59 # v1
+      with:
+        bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
 
     - name: Install dependencies
       run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
       contents: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version-file: .node-version
         cache: pnpm
@@ -49,13 +49,13 @@ jobs:
       contents: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version-file: .node-version
         cache: pnpm
@@ -78,13 +78,13 @@ jobs:
       contents: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version-file: .node-version
         cache: pnpm
@@ -103,7 +103,7 @@ jobs:
       run: pnpm site-build
 
     - name: Archive feed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: feed-generate-results
         path: public/feeds

--- a/.github/workflows/generate-feed.yml
+++ b/.github/workflows/generate-feed.yml
@@ -14,6 +14,9 @@ jobs:
     name: Generate Feed
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: write
 
     steps:
       - name: Git checkout
@@ -29,6 +32,10 @@ jobs:
         with:
           node-version-file: .node-version
           cache: pnpm
+
+      - uses: flatt-security/setup-takumi-guard-npm@8f53b50568e4466f2d92504f349c05b9ffcb8b59 # v1
+        with:
+          bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
 
       - name: Install node packages
         run: pnpm install

--- a/.github/workflows/generate-feed.yml
+++ b/.github/workflows/generate-feed.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       id-token: write
-      contents: write
+      contents: write # NOTE: peaceiris/actions-gh-pages で gh-pages に push するため、contents は write に
 
     steps:
       - name: Git checkout

--- a/.github/workflows/generate-feed.yml
+++ b/.github/workflows/generate-feed.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version-file: .node-version
           cache: pnpm
@@ -47,7 +47,7 @@ jobs:
         shell: bash
 
       - name: Cache feed images
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.4
         with:
           path: .cache
           key: ${{ runner.os }}-feed-images-${{ steps.get-date.outputs.date }}
@@ -59,7 +59,7 @@ jobs:
         run: pnpm site-build
 
       - name: Push to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public


### PR DESCRIPTION
ConnectTask-5389 Takumi Guard対応しました。

1. Takumi Guard追加、checkout、pnpmをアナウンスされていたバージョンに変更、
setup_nodeをv6、actions/cacheをv5.0.4、peaceiris/actions-gh-pagesをv4.0.0、
actions/upload-artifactをv7.0.1にSHAハッシュ固定
- ci.yml
- generate-feed.yml

※TAKUMI_GUARD_BOT_IDは、orgでvars設定済
